### PR TITLE
Add e2e testing to spdy proxy support using netexec

### DIFF
--- a/contrib/for-tests/netexec/Dockerfile
+++ b/contrib/for-tests/netexec/Dockerfile
@@ -3,5 +3,9 @@ MAINTAINER Abhishek Shah "abshah@google.com"
 
 ADD netexec netexec
 ADD netexec.go netexec.go
+EXPOSE 8080
+EXPOSE 8081
+
+RUN mkdir /uploads
 
 ENTRYPOINT ["/netexec"]

--- a/contrib/for-tests/netexec/Makefile
+++ b/contrib/for-tests/netexec/Makefile
@@ -1,11 +1,9 @@
 .PHONY: all netexec image push clean
 
-TAG = 1.0
+TAG = 1.1
 PREFIX = gcr.io/google_containers
 
 all: push
-
-TAG = 1.0
 
 netexec: netexec.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./netexec.go

--- a/contrib/for-tests/netexec/netexec.go
+++ b/contrib/for-tests/netexec/netexec.go
@@ -193,8 +193,12 @@ func dialUDP(request string, remoteAddress *net.UDPAddr) (string, error) {
 
 func shellHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.FormValue("shellCommand"))
-	output, err := exec.Command(shellPath, "-c", r.FormValue("shellCommand")).CombinedOutput()
-	assertNoError(err)
+	log.Printf("%s %s %s\n", shellPath, "-c", r.FormValue("shellCommand"))
+	cmd := exec.Command(shellPath, "-c", r.FormValue("shellCommand"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error running command: %s", err)
+	}
 	fmt.Fprintf(w, string(output))
 }
 

--- a/contrib/for-tests/netexec/pod.yaml
+++ b/contrib/for-tests/netexec/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netexec
+  labels:
+    app: netexec
+spec:
+  containers:
+  - name: netexec
+    image: gcr.io/google_containers/netexec:1.1
+    ports:
+    - containerPort: 8080
+    - containerPort: 8081

--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -78,11 +78,14 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return s.dialWithoutProxy(req.URL)
 	}
 
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(req.URL)
+
 	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
 	proxyReq := http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{},
-		Host:   req.URL.Host,
+		Host:   targetHost,
 	}
 
 	proxyDialConn, err := s.dialWithoutProxy(proxyURL)

--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -52,21 +54,82 @@ type SpdyRoundTripper struct {
 	Dialer *net.Dialer
 }
 
-// NewSpdyRoundTripper creates a new SpdyRoundTripper that will use
+// NewRoundTripper creates a new SpdyRoundTripper that will use
 // the specified tlsConfig.
 func NewRoundTripper(tlsConfig *tls.Config) httpstream.UpgradeRoundTripper {
 	return NewSpdyRoundTripper(tlsConfig)
 }
 
+// NewSpdyRoundTripper creates a new SpdyRoundTripper that will use
+// the specified tlsConfig. This function is mostly meant for unit tests.
 func NewSpdyRoundTripper(tlsConfig *tls.Config) *SpdyRoundTripper {
 	return &SpdyRoundTripper{tlsConfig: tlsConfig}
 }
 
-// dial dials the host specified by req, using TLS if appropriate.
+// dial dials the host specified by req, using TLS if appropriate, optionally
+// using a proxy server if one is configured via environment variables.
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
-	dialAddr := netutil.CanonicalAddr(req.URL)
+	proxyURL, err := http.ProxyFromEnvironment(req)
+	if err != nil {
+		return nil, err
+	}
 
-	if req.URL.Scheme == "http" {
+	if proxyURL == nil {
+		return s.dialWithoutProxy(req.URL)
+	}
+
+	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
+	proxyReq := http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{},
+		Host:   req.URL.Host,
+	}
+
+	proxyDialConn, err := s.dialWithoutProxy(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
+	_, err = proxyClientConn.Do(&proxyReq)
+	if err != nil && err != httputil.ErrPersistEOF {
+		return nil, err
+	}
+
+	rwc, _ := proxyClientConn.Hijack()
+
+	if req.URL.Scheme != "https" {
+		return rwc, nil
+	}
+
+	host, _, err := net.SplitHostPort(req.URL.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(s.tlsConfig.ServerName) == 0 {
+		s.tlsConfig.ServerName = host
+	}
+
+	tlsConn := tls.Client(rwc, s.tlsConfig)
+
+	// need to manually call Handshake() so we can call VerifyHostname() below
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, err
+	}
+
+	if err := tlsConn.VerifyHostname(host); err != nil {
+		return nil, err
+	}
+
+	return tlsConn, nil
+}
+
+// dialWithoutProxy dials the host specified by url, using TLS if appropriate.
+func (s *SpdyRoundTripper) dialWithoutProxy(url *url.URL) (net.Conn, error) {
+	dialAddr := netutil.CanonicalAddr(url)
+
+	if url.Scheme == "http" {
 		if s.Dialer == nil {
 			return net.Dial("tcp", dialAddr)
 		} else {

--- a/test/images/goproxy/.gitignore
+++ b/test/images/goproxy/.gitignore
@@ -1,0 +1,1 @@
+goproxy

--- a/test/images/goproxy/Dockerfile
+++ b/test/images/goproxy/Dockerfile
@@ -14,4 +14,5 @@
 
 FROM scratch
 ADD goproxy goproxy
+EXPOSE 8080
 ENTRYPOINT ["/goproxy"]

--- a/test/images/goproxy/Dockerfile
+++ b/test/images/goproxy/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+ADD goproxy goproxy
+ENTRYPOINT ["/goproxy"]

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -1,0 +1,15 @@
+all: push
+
+TAG = 0.1
+
+goproxy: goproxy.go
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./goproxy.go
+
+image: goproxy
+	sudo docker build -t gcr.io/google_containers/goproxy:$(TAG) .
+
+push: image
+	gcloud docker push gcr.io/google_containers/goproxy:$(TAG)
+
+clean:
+	rm -f goproxy

--- a/test/images/goproxy/goproxy.go
+++ b/test/images/goproxy/goproxy.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/elazarl/goproxy"
+)
+
+func main() {
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
+	log.Fatal(http.ListenAndServe(":8080", proxy))
+}

--- a/test/images/goproxy/pod.yaml
+++ b/test/images/goproxy/pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: goproxy
+  labels:
+    app: goproxy
+spec:
+  containers:
+  - name: goproxy
+    image: gcr.io/google_containers/goproxy:0.1
+    ports:
+    - containerPort: 8080


### PR DESCRIPTION
Verified using ginkgo against a local cluster as originally discussed. This supersedes #3.
## Changes
- rebased on kubernetes/master (hence the non automatic merge)
- https://github.com/ncdc/kubernetes/commit/2b4dcdf08b31c46992a4411841d6e854911ad292: url.URL.Host now canonical before use in spdy roundtripper 
- https://github.com/ncdc/kubernetes/commit/c7b1a48e7c80d1c74d6953bf6c0e28bafb939e91: Fixes netexec Makefiles TAG variable: 
- https://github.com/ncdc/kubernetes/commit/9e4ef014ca491693f7a8b845fe323e75516fe335
  - Adds upload functionality
  - Adds EXPOSE to the Dockerfile
- https://github.com/ncdc/kubernetes/commit/704e1a08566524b008ad6790023d6399b645964b: Adds a pod.yaml for netexec
- https://github.com/ncdc/kubernetes/commit/017d11ef17ff83539ac8dbe72c65141f9f476f79: Adds more logging for shell handler: 
- https://github.com/ncdc/kubernetes/commit/f53d5cab6805d35e643b0f7d939cd744919ca48b
  - pod file for goproxy added 
  - EXPOSE added to Dockerfile
- https://github.com/ncdc/kubernetes/commit/b79bc657c89cce046460b402b5faf128b0377ef9: e2e updates in `test/e2e/kubectl.go` to enable testing: 
## Notes

e2e requires two new environment variables.
- `KUBECTLBIN`: The full path to a _static_ `kubectl` binary
- `APISERVERADDR`: Full URL to the API server (IE: http://10.10.10.10:8080). This is fed in to the exec-proxy-test pod as its `kubectl --server` option.
