### PR TITLE
Now kubectl through https uses gce

### DIFF
--- a/contrib/for-tests/netexec/Dockerfile
+++ b/contrib/for-tests/netexec/Dockerfile
@@ -3,5 +3,9 @@ MAINTAINER Abhishek Shah "abshah@google.com"
 
 ADD netexec netexec
 ADD netexec.go netexec.go
+EXPOSE 8080
+EXPOSE 8081
+
+RUN mkdir /uploads
 
 ENTRYPOINT ["/netexec"]

--- a/contrib/for-tests/netexec/Makefile
+++ b/contrib/for-tests/netexec/Makefile
@@ -1,11 +1,9 @@
 .PHONY: all netexec image push clean
 
-TAG = 1.0
+TAG = 1.1
 PREFIX = gcr.io/google_containers
 
 all: push
-
-TAG = 1.0
 
 netexec: netexec.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./netexec.go

--- a/contrib/for-tests/netexec/Makefile
+++ b/contrib/for-tests/netexec/Makefile
@@ -1,7 +1,9 @@
 .PHONY: all netexec image push clean
 
-TAG = 1.1
-PREFIX = gcr.io/google_containers
+TAG = 1.2
+# TODO: update before merge to gcr.io once accepted for merge and image is uploaded
+#PREFIX = gcr.io/google_containers
+PREFIX = stevemilnerrh
 
 all: push
 

--- a/contrib/for-tests/netexec/netexec.go
+++ b/contrib/for-tests/netexec/netexec.go
@@ -195,10 +195,12 @@ func shellHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.FormValue("shellCommand"))
 	log.Printf("%s %s %s\n", shellPath, "-c", r.FormValue("shellCommand"))
 	cmd := exec.Command(shellPath, "-c", r.FormValue("shellCommand"))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Printf("Error running command: %s", err)
 	}
+	log.Printf("Output: %s", output)
 	fmt.Fprintf(w, string(output))
 }
 

--- a/contrib/for-tests/netexec/netexec.go
+++ b/contrib/for-tests/netexec/netexec.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -58,6 +59,7 @@ func startHTTPServer(httpPort int) {
 	http.HandleFunc("/shutdown", shutdownHandler)
 	http.HandleFunc("/hostName", hostNameHandler)
 	http.HandleFunc("/shell", shellHandler)
+	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/dial", dialHandler)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", httpPort), nil))
 }
@@ -191,9 +193,50 @@ func dialUDP(request string, remoteAddress *net.UDPAddr) (string, error) {
 
 func shellHandler(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.FormValue("shellCommand"))
-	output, err := exec.Command(shellPath, "-c", r.FormValue("shellCommand")).CombinedOutput()
-	assertNoError(err)
+	log.Printf("%s %s %s\n", shellPath, "-c", r.FormValue("shellCommand"))
+	cmd := exec.Command(shellPath, "-c", r.FormValue("shellCommand"))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Error running command: %s", err)
+	}
 	fmt.Fprintf(w, string(output))
+}
+
+func uploadHandler(w http.ResponseWriter, r *http.Request) {
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Unable to upload file.")
+		log.Printf("Unable to upload file: %s", err)
+		return
+	}
+	defer file.Close()
+
+	f, err := ioutil.TempFile("/uploads", "upload")
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Unable to open file for write.")
+		log.Printf("Unable to open file for write: %s", err)
+		return
+	}
+	defer f.Close()
+	if _, err = io.Copy(f, file); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Unable to write file."))
+		log.Printf("Unable to write file: %s", err)
+		return
+	}
+
+	UploadFile := f.Name()
+	if err := os.Chmod(UploadFile, 0700); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Unable to chmod file.")
+		log.Printf("Unable to chmod file: %s", err)
+		return
+	}
+	log.Printf("Wrote upload to %s", UploadFile)
+	w.WriteHeader(http.StatusCreated)
+	fmt.Fprintf(w, UploadFile)
 }
 
 func hostNameHandler(w http.ResponseWriter, r *http.Request) {

--- a/contrib/for-tests/netexec/pod.yaml
+++ b/contrib/for-tests/netexec/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: netexec
+  labels:
+    app: netexec
+spec:
+  containers:
+  - name: netexec
+    image: gcr.io/google_containers/netexec:1.1
+    ports:
+    - containerPort: 8080
+    - containerPort: 8081

--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -78,11 +78,14 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return s.dialWithoutProxy(req.URL)
 	}
 
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(req.URL)
+
 	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
 	proxyReq := http.Request{
 		Method: "CONNECT",
 		URL:    &url.URL{},
-		Host:   req.URL.Host,
+		Host:   targetHost,
 	}
 
 	proxyDialConn, err := s.dialWithoutProxy(proxyURL)

--- a/test/images/goproxy/Dockerfile
+++ b/test/images/goproxy/Dockerfile
@@ -14,4 +14,5 @@
 
 FROM scratch
 ADD goproxy goproxy
+EXPOSE 8080
 ENTRYPOINT ["/goproxy"]

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -1,3 +1,4 @@
+# TODO: update before merge to gcr.io once accepted for merge and image is uploaded
 all: push
 
 TAG = 0.1
@@ -6,10 +7,10 @@ goproxy: goproxy.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./goproxy.go
 
 image: goproxy
-	sudo docker build -t gcr.io/google_containers/goproxy:$(TAG) .
+	sudo docker build -t stevemilnerrh/goproxy:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/goproxy:$(TAG)
+	gcloud docker push stevemilnerrh/goproxy:$(TAG)
 
 clean:
 	rm -f goproxy

--- a/test/images/goproxy/pod.yaml
+++ b/test/images/goproxy/pod.yaml
@@ -2,13 +2,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: netexec
+  name: goproxy
   labels:
-    app: netexec
+    app: goproxy
 spec:
   containers:
-  - name: netexec
-    image: stevemilnerrh/netexec:1.2
+  - name: goproxy
+    image: stevemilnerrh/goproxy:0.1
     ports:
     - containerPort: 8080
-    - containerPort: 8081


### PR DESCRIPTION
# GCE spdy proxy e2e tests

This is a modification of #4 . The changes are the same but much of the internals have been updated to utilize `testContext` instead of environment variables, using SSL and tokens for `netexec`'s `kubectl` calls, and `unversioned.Client` for proxying through the api server to pods. No new arguments have been added to the `e2e.test` binary. 
## Notes
### Images

The `pods.yaml` for both `netexec` and `goproxy` have been temporarily changed to point to dockerhub where I have the test images posted.
### Running

[This](https://github.com/kubernetes/kubernetes/blob/master/hack/ginkgo-e2e.sh) is called when running the e2e tests which insinuates that `kubectl` will be available on the system running the tests.
- `---host` must be $SCHEME$HOST:$PORT/api: https://127.0.0.1:443/api
- `--kubectl-path` must be a real path to the kubectl binary
- `---kubeconfig` must be a valid kubeconfig with an e2e user that has a token

```
[e2e/]$ e2e.test --host="https://API_SERVER:443/api" --provider="gce" --ginkgo.v=true --ginkgo.focus="support exec through an HTTP proxy" --kubeconfig="$HOME/.kube/config" --kubectl-path=`which kubectl`
```
